### PR TITLE
Close accounts tab with the finish button in firefox

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -6,8 +6,8 @@ import { extension } from 'lib/extension';
 import { ERRORS } from 'lib/keeperError';
 import { PortStream } from 'lib/portStream';
 import {
-  ExtensionStorage,
   backupStorage,
+  ExtensionStorage,
   StorageLocalState,
 } from './storage/storage';
 import { getFirstLangCode } from 'lib/getFirstLangCode';
@@ -193,6 +193,9 @@ async function setupBackgroundService() {
   backgroundService.on('Show tab', async (url, name) => {
     backgroundService.emit('closePopupWindow');
     return tabsManager.getOrCreate(url, name);
+  });
+  backgroundService.on('Close current tab', async () => {
+    return tabsManager.closeCurrentTab();
   });
 
   return backgroundService;
@@ -663,8 +666,13 @@ class BackgroundService extends EventEmitter {
       resizeNotificationWindow: async (width: number, height: number) =>
         this.emit('Resize notification', width, height),
 
-      showTab: async (url: string, name: string) =>
-        this.emit('Show tab', url, name),
+      showTab: async (url: string, name: string) => {
+        this.emit('Show tab', url, name);
+      },
+
+      closeCurrentTab: async () => {
+        this.emit('Close current tab');
+      },
 
       // origin settings
       allowOrigin: async (origin: string) => {

--- a/src/lib/tabsManager.ts
+++ b/src/lib/tabsManager.ts
@@ -40,4 +40,13 @@ export class TabsManager {
       })
     );
   }
+
+  async closeCurrentTab() {
+    extension.tabs.query(
+      { active: true, lastFocusedWindow: true },
+      tab =>
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        tab[0] && extension.tabs.remove([tab[0].id!])
+    );
+  }
 }

--- a/src/ui/components/pages/importSuccess.tsx
+++ b/src/ui/components/pages/importSuccess.tsx
@@ -6,6 +6,7 @@ import { Button } from '../ui';
 import { PAGES } from '../../pageConfig';
 import { useAccountsSelector, useAppDispatch } from 'accounts/store';
 import { setTab } from 'ui/actions';
+import background from 'ui/services/Background';
 
 export function ImportSuccessAddressBook() {
   const { t } = useTranslation();
@@ -28,7 +29,7 @@ export function ImportSuccessAddressBook() {
           className={styles.button}
           type="submit"
           view="submit"
-          onClick={() => window.close()}
+          onClick={() => background.closeCurrentTab()}
         >
           {t('import.finish')}
         </Button>
@@ -76,7 +77,7 @@ export function ImportSuccess() {
           className={styles.button}
           type="submit"
           view="submit"
-          onClick={() => window.close()}
+          onClick={() => background.closeCurrentTab()}
         >
           {t('import.finish')}
         </Button>

--- a/src/ui/services/Background.ts
+++ b/src/ui/services/Background.ts
@@ -253,8 +253,20 @@ class Background {
       await this.initPromise;
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       await this._connect!();
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-explicit-any
-      return (await this.background!.showTab(url, name)) as any;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return await this.background!.showTab(url, name);
+    } catch (err) {
+      throw new Error(prepareErrorMessage(err));
+    }
+  }
+
+  async closeCurrentTab(): Promise<void> {
+    try {
+      await this.initPromise;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      await this._connect!();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return await this.background!.closeCurrentTab();
     } catch (err) {
       throw new Error(prepareErrorMessage(err));
     }


### PR DESCRIPTION
The firefox security policy does not allow a `window.close()` if it is not opened by a script